### PR TITLE
Update eye rejection to handle saccades, require artifacts in both eyes

### DIFF
--- a/eegreject.m
+++ b/eegreject.m
@@ -210,33 +210,23 @@ for subdir=1:numel(subjectDirectories)
             sprintf('y-saccade rejection: %i', sum(y_saccade_reject))
             saccade_reject = x_saccade_reject | y_saccade_reject;
             
+            % COMBINE DRIFT & SACCADE REJECTIONS
+            eye_reject = drift_reject | saccade_reject;
+            EEG.reject.rejmanual = eye_reject;
+        
             % ADD CHANNEL SPECIFIC FLAGS FOR VISUALIZING
-            EEG.reject.rejmanualE(allChanNumbers(ismember({EEG.chanlocs.labels}, {'L_GAZE_X', 'R_GAZE_X'})), :) = repmat(x_drift_reject | x_saccade_reject, 2,1);
-            EEG.reject.rejmanualE(allChanNumbers(ismember({EEG.chanlocs.labels}, {'L_GAZE_Y', 'R_GAZE_Y'})), :) = repmat(y_drift_reject | y_saccade_reject, 2,1);
+            EEG.reject.rejmanualE(allChanNumbers(ismember({EEG.chanlocs.labels}, {'L-GAZE-X', 'R-GAZE-X'})), :) = repmat(x_drift_reject | x_saccade_reject, 2,1);
+            EEG.reject.rejmanualE(allChanNumbers(ismember({EEG.chanlocs.labels}, {'L-GAZE-Y', 'R-GAZE-Y'})), :) = repmat(y_drift_reject | y_saccade_reject, 2,1);
             
         else
             % CHECKING FOR DRIFT
-            x_drift_reject = pop_artextval(EEG , 'Channel',  allChanNumbers(ismember({EEG.chanlocs.labels}, {'GAZE-X'})), 'Flag',  1, 'Threshold', [-GazeDistThresh_x GazeDistThresh_x], 'Twindow', [rejectionStart rejectionEnd]);
-            sprintf('x-drift rejection: %i', sum(x_drift_reject))
-            y_drift_reject = pop_artextval(EEG , 'Channel',  allChanNumbers(ismember({EEG.chanlocs.labels}, {'GAZE-Y'})), 'Flag',  1, 'Threshold', [-GazeDistThresh_y GazeDistThresh_y], 'Twindow', [rejectionStart rejectionEnd]);
-            sprintf('y-drift rejection: %i', sum(y_drift_reject))
-            drift_reject = x_drift_reject | y_drift_reject;
+            EEG = pop_artextval(EEG , 'Channel',  allChanNumbers(ismember({EEG.chanlocs.labels}, {'GAZE-X'})), 'Flag',  1, 'Threshold', [-GazeDistThresh_x GazeDistThresh_x], 'Twindow', [rejectionStart rejectionEnd]);
+            EEG = pop_artextval(EEG , 'Channel',  allChanNumbers(ismember({EEG.chanlocs.labels}, {'GAZE-Y'})), 'Flag',  1, 'Threshold', [-GazeDistThresh_y GazeDistThresh_y], 'Twindow', [rejectionStart rejectionEnd]);
             
             % CHECKING FOR SACCADES
-            x_saccade_reject = pop_artstep(EEG , 'Channel',  allChanNumbers(ismember({EEG.chanlocs.labels}, {'GAZE-X'})), 'Flag',  1, 'Threshold', GazeSaccadeThresh_x, 'Twindow', [rejectionStart rejectionEnd], 'Windowsize', eyeSaccadeWindow, 'Windowstep', eyeSaccadeStep);
-            sprintf('x-saccade rejection: %i', sum(x_saccade_reject))
-            y_saccade_reject = pop_artstep(EEG , 'Channel',  allChanNumbers(ismember({EEG.chanlocs.labels}, {'GAZE-Y'})), 'Flag',  1, 'Threshold', GazeSaccadeThresh_y, 'Twindow', [rejectionStart rejectionEnd], 'Windowsize', eyeSaccadeWindow, 'Windowstep', eyeSaccadeStep);
-            sprintf('y-saccade rejection: %i', sum(y_saccade_reject))
-            saccade_reject = x_saccade_reject | y_saccade_reject;
-            
-            % ADD CHANNEL SPECIFIC FLAGS FOR VISUALIZING
-            EEG.reject.rejmanualE(allChanNumbers(ismember({EEG.chanlocs.labels}, {'GAZE-X'})), :) = x_drift_reject | x_saccade_reject;
-            EEG.reject.rejmanualE(allChanNumbers(ismember({EEG.chanlocs.labels}, {'GAZE-Y'})), :) = y_drift_reject | y_saccade_reject;
+            EEG = pop_artstep(EEG , 'Channel',  allChanNumbers(ismember({EEG.chanlocs.labels}, {'GAZE-X'})), 'Flag',  1, 'Threshold', GazeSaccadeThresh_x, 'Twindow', [rejectionStart rejectionEnd], 'Windowsize', eyeSaccadeWindow, 'Windowstep', eyeSaccadeStep);
+            EEG = pop_artstep(EEG , 'Channel',  allChanNumbers(ismember({EEG.chanlocs.labels}, {'GAZE-Y'})), 'Flag',  1, 'Threshold', GazeSaccadeThresh_y, 'Twindow', [rejectionStart rejectionEnd], 'Windowsize', eyeSaccadeWindow, 'Windowstep', eyeSaccadeStep);
         end
-        
-        % COMBINE DRIFT & SACCADE REJECTIONS
-        eye_reject = drift_reject | saccade_reject;
-        EEG.reject.rejmanual = eye_reject;
     end
     
     %EOG ARTIFACT REJECTION

--- a/eegreject.m
+++ b/eegreject.m
@@ -32,15 +32,19 @@ baselineEnd = 0;
 rejectionStart = -200;
 rejectionEnd = 1250;
 
-eyeMoveThresh = 0.5;  %deg
+eegResampleRate = 500; %hz
+eegResample = true;
+
 distFromScreen = 738; %mm
 monitorWidth = 532;  %mm
 monitorHeight = 300;  %mm
 screenResX = 1920;  %px
 screenResY = 1080;  %px
 
-eegResampleRate = 500; %hz
-eegResample = true;
+eyeDistThresh = 1;  %deg
+eyeSaccadeThresh = .5;  %deg
+eyeSaccadeWindow = 80; %ms
+eyeSaccadeStep = 10; %ms
 
 eogThresh = 50; %microv
 
@@ -73,7 +77,8 @@ end
 log = fopen('log.txt', 'a+t');
 fprintf(log, ['Run started: ', datestr(now), '\n\n']);
 
-maximumGazeDist = calcdeg2pix(eyeMoveThresh, distFromScreen, monitorWidth, monitorHeight, screenResX, screenResY);
+[GazeDistThresh_x, GazeDistThresh_y] = calcdeg2pix(eyeDistThresh, distFromScreen, monitorWidth, monitorHeight, screenResX, screenResY);
+[GazeSaccadeThresh_x, GazeSaccadeThresh_y] = calcdeg2pix(eyeSaccadeThresh, distFromScreen, monitorWidth, monitorHeight, screenResX, screenResY);
 %% Main loop
 
 for subdir=1:numel(subjectDirectories)
@@ -174,9 +179,61 @@ for subdir=1:numel(subjectDirectories)
     
     %EYETRACKING ARTIFACT REJECTION
     if ~any(strcmp(noEyetracking,subject_number)) %if the subject has eyetracking
-        eyetrackingIDX = allChanNumbers(ismember({EEG.chanlocs.labels}, {'L_GAZE_X','L_GAZE_Y','R_GAZE_X','R_GAZE_Y','GAZE-X','GAZE-Y'}));    
-        %flags trials where absolute eyetracking value is greater than maximumGazeDist
-        EEG = pop_artextval(EEG , 'Channel',  eyetrackingIDX, 'Flag',  1, 'Threshold', [-maximumGazeDist maximumGazeDist], 'Twindow', [rejectionStart rejectionEnd]);
+        if strcmp(eyeRecorded, 'both')
+            % CHECKING FOR DRIFT IN BOTH EYES
+            % x-direction
+            EEG_x_left = pop_artextval(EEG , 'Channel',  allChanNumbers(ismember({EEG.chanlocs.labels}, {'L_GAZE_X'})), 'Flag',  1, 'Threshold', [-GazeDistThresh_x GazeDistThresh_x], 'Twindow', [rejectionStart rejectionEnd]);
+            EEG_x_right = pop_artextval(EEG , 'Channel',  allChanNumbers(ismember({EEG.chanlocs.labels}, {'R_GAZE_X'})), 'Flag',  1, 'Threshold', [-GazeDistThresh_x GazeDistThresh_x], 'Twindow', [rejectionStart rejectionEnd]);
+            x_drift_reject = EEG_x_left.reject.rejmanual .* EEG_x_right.reject.rejmanual;
+            sprintf('x-drift rejection: %i', sum(x_drift_reject))
+            % y-direction
+            EEG_y_left = pop_artextval(EEG , 'Channel',  allChanNumbers(ismember({EEG.chanlocs.labels}, {'L_GAZE_Y'})), 'Flag',  1, 'Threshold', [-GazeDistThresh_y GazeDistThresh_y], 'Twindow', [rejectionStart rejectionEnd]);
+            EEG_y_right = pop_artextval(EEG , 'Channel',  allChanNumbers(ismember({EEG.chanlocs.labels}, {'R_GAZE_Y'})), 'Flag',  1, 'Threshold', [-GazeDistThresh_y GazeDistThresh_y], 'Twindow', [rejectionStart rejectionEnd]);
+            y_drift_reject = EEG_y_left.reject.rejmanual .* EEG_y_right.reject.rejmanual;
+            
+            sprintf('y-drift rejection: %i', sum(y_drift_reject))
+            drift_reject = x_drift_reject | y_drift_reject;
+            
+            % CHECKING FOR SACCADES IN BOTH EYES
+            % x-direction
+            EEG_x_left = pop_artstep(EEG , 'Channel',  allChanNumbers(ismember({EEG.chanlocs.labels}, {'L_GAZE_X'})), 'Flag',  1, 'Threshold', GazeSaccadeThresh_x, 'Twindow', [rejectionStart rejectionEnd], 'Windowsize', eyeSaccadeWindow, 'Windowstep', eyeSaccadeStep);
+            EEG_x_right = pop_artstep(EEG , 'Channel',  allChanNumbers(ismember({EEG.chanlocs.labels}, {'R_GAZE_X'})), 'Flag',  1, 'Threshold', GazeSaccadeThresh_x, 'Twindow', [rejectionStart rejectionEnd], 'Windowsize', eyeSaccadeWindow, 'Windowstep', eyeSaccadeStep);
+            x_saccade_reject = EEG_x_left.reject.rejmanual .* EEG_x_right.reject.rejmanual;
+            sprintf('x-saccade rejection: %i', sum(x_saccade_reject))
+            % y-direction
+            EEG_y_left = pop_artstep(EEG , 'Channel',  allChanNumbers(ismember({EEG.chanlocs.labels}, {'L_GAZE_Y'})), 'Flag',  1, 'Threshold', GazeSaccadeThresh_y, 'Twindow', [rejectionStart rejectionEnd], 'Windowsize', eyeSaccadeWindow, 'Windowstep', eyeSaccadeStep);
+            EEG_y_right = pop_artstep(EEG , 'Channel',  allChanNumbers(ismember({EEG.chanlocs.labels}, {'R_GAZE_Y'})), 'Flag',  1, 'Threshold', GazeSaccadeThresh_y, 'Twindow', [rejectionStart rejectionEnd], 'Windowsize', eyeSaccadeWindow, 'Windowstep', eyeSaccadeStep);
+            y_saccade_reject = EEG_y_left.reject.rejmanual .* EEG_y_right.reject.rejmanual;
+            sprintf('y-saccade rejection: %i', sum(y_saccade_reject))
+            saccade_reject = x_saccade_reject | y_saccade_reject;
+            
+            % ADD CHANNEL SPECIFIC FLAGS FOR VISUALIZING
+            EEG.reject.rejmanualE(allChanNumbers(ismember({EEG.chanlocs.labels}, {'L_GAZE_X', 'R_GAZE_X'})), :) = repmat(x_drift_reject | x_saccade_reject, 2,1);
+            EEG.reject.rejmanualE(allChanNumbers(ismember({EEG.chanlocs.labels}, {'L_GAZE_Y', 'R_GAZE_Y'})), :) = repmat(y_drift_reject | y_saccade_reject, 2,1);
+            
+        else
+            % CHECKING FOR DRIFT
+            x_drift_reject = pop_artextval(EEG , 'Channel',  allChanNumbers(ismember({EEG.chanlocs.labels}, {'GAZE-X'})), 'Flag',  1, 'Threshold', [-GazeDistThresh_x GazeDistThresh_x], 'Twindow', [rejectionStart rejectionEnd]);
+            sprintf('x-drift rejection: %i', sum(x_drift_reject))
+            y_drift_reject = pop_artextval(EEG , 'Channel',  allChanNumbers(ismember({EEG.chanlocs.labels}, {'GAZE-Y'})), 'Flag',  1, 'Threshold', [-GazeDistThresh_y GazeDistThresh_y], 'Twindow', [rejectionStart rejectionEnd]);
+            sprintf('y-drift rejection: %i', sum(y_drift_reject))
+            drift_reject = x_drift_reject | y_drift_reject;
+            
+            % CHECKING FOR SACCADES
+            x_saccade_reject = pop_artstep(EEG , 'Channel',  allChanNumbers(ismember({EEG.chanlocs.labels}, {'GAZE-X'})), 'Flag',  1, 'Threshold', GazeSaccadeThresh_x, 'Twindow', [rejectionStart rejectionEnd], 'Windowsize', eyeSaccadeWindow, 'Windowstep', eyeSaccadeStep);
+            sprintf('x-saccade rejection: %i', sum(x_saccade_reject))
+            y_saccade_reject = pop_artstep(EEG , 'Channel',  allChanNumbers(ismember({EEG.chanlocs.labels}, {'GAZE-Y'})), 'Flag',  1, 'Threshold', GazeSaccadeThresh_y, 'Twindow', [rejectionStart rejectionEnd], 'Windowsize', eyeSaccadeWindow, 'Windowstep', eyeSaccadeStep);
+            sprintf('y-saccade rejection: %i', sum(y_saccade_reject))
+            saccade_reject = x_saccade_reject | y_saccade_reject;
+            
+            % ADD CHANNEL SPECIFIC FLAGS FOR VISUALIZING
+            EEG.reject.rejmanualE(allChanNumbers(ismember({EEG.chanlocs.labels}, {'GAZE-X'})), :) = x_drift_reject | x_saccade_reject;
+            EEG.reject.rejmanualE(allChanNumbers(ismember({EEG.chanlocs.labels}, {'GAZE-Y'})), :) = y_drift_reject | y_saccade_reject;
+        end
+        
+        % COMBINE DRIFT & SACCADE REJECTIONS
+        eye_reject = drift_reject | saccade_reject;
+        EEG.reject.rejmanual = eye_reject;
     end
     
     %EOG ARTIFACT REJECTION

--- a/eegreject.m
+++ b/eegreject.m
@@ -272,6 +272,6 @@ function [xPix, yPix] = calcdeg2pix(eyeMoveThresh, distFromScreen, monitorWidth,
 
     mmfromfix = (2*distFromScreen) * tan(.5 * deg2rad(eyeMoveThresh));
 
-    xPix = round(mmfromfix/pixSize.X);
-    yPix = round(mmfromfix/pixSize.Y);
+    xPix = mmfromfix/pixSize.X;
+    yPix = mmfromfix/pixSize.Y;
 end

--- a/eegreject.m
+++ b/eegreject.m
@@ -6,8 +6,8 @@ eeglab
 
 %% Options
 
-subjectParentDir = '../Acacia_Exp1/DATA-EEG';
-subjectDirectories = {'004'};  % optionally {} for recursive search
+subjectParentDir = 'test_data';
+subjectDirectories = {'6'};  % optionally {} for recursive search
 noEyetracking = {};  %list all subjects who don't have ET data
 doEogRejection = {}; %no EOG rejection by default, add subjects to do EOG rejection (usually those who don't have ET data).
 
@@ -18,18 +18,18 @@ rerefType = 'mastoid'; % 'none', 'average', or 'mastoid'
 rerefExcludeChans = {'HEOG', 'VEOG', 'StimTrak'};
 customEquationList = '';  % optional
 
-EYEEEGKeyword = 'SYNC';
-startEvent = 190; %P001=223, P002=211
-endEvent = 191;
+EYEEEGKeyword = 'sync';
+startEvent = 21;
+endEvent = 21;
 eyeRecorded = 'left';  % 'both', 'left', or 'right'
 
 binlistFile = '';  % if empty, will create one for you
-timelockCodes = [211, 213, 221, 222, 223];  % codes to timelock to
-trialStart = -250;
+timelockCodes = [11 12 13 14];  % codes to timelock to
+trialStart = -200;
 trialEnd = 1250;
-baselineStart = -250;
-baselineEnd = -50;
-rejectionStart = -250;
+baselineStart = -200;
+baselineEnd = 0;
+rejectionStart = -200;
 rejectionEnd = 1250;
 
 eegResampleRate = 500; %hz

--- a/eegreject.m
+++ b/eegreject.m
@@ -47,6 +47,9 @@ eyeSaccadeWindow = 80; %ms
 eyeSaccadeStep = 10; %ms
 
 eogThresh = 50; %microv
+eogSaccadeThresh = 20;  %microv
+eogSaccadeWindow = 150; %ms
+eogSaccadeStep = 10; %ms
 
 eegAbsThresh = 100; %microv
 eegNoiseThresh = 75; %microv 
@@ -241,6 +244,7 @@ for subdir=1:numel(subjectDirectories)
         eogIDX = allChanNumbers(ismember({EEG.chanlocs.labels}, {'HEOG','VEOG'}));    
         %flags trials where absolute EOG value is greather than eogThresh
         EEG = pop_artextval(EEG , 'Channel',  eogIDX, 'Flag',  2, 'Threshold', [-eogThresh eogThresh], 'Twindow', [rejectionStart rejectionEnd]);
+        EEG = pop_artstep(EEG , 'Channel',  eogIDX, 'Flag',  2, 'Threshold', eogSaccadeThresh, 'Twindow', [rejectionStart rejectionEnd], 'Windowsize', eogSaccadeWindow, 'Windowstep', eogSaccadeStep);
     end
     
     %EEG ARTIFACT REJECTION


### PR DESCRIPTION
This PR makes a number of improvements to the handling of eye artifacts:

1. The number of pixels returned from calcdeg2pix is now precise, rather than rounded. This is better because the actual values from the eye tracker are also precise.
2. While assessing eyes, distances in x-pixels and y-pixels are now compared separately, to account for the fact that the pixels are slightly rectangular.
3. Saccade rejection has been added for both eye tracking and EOG data, following the recommended values of Diaz et al., 2021. Note that the EOG based saccade rejection (20 microvolt differences between the first half and the second half of a 150ms window) subsumes EOG based blink rejection in that same paper (30 microvolt differences between the halves of the same window), so EOG based blink rejection is also added.
4. If both eyes are tracked, then an artifact needs to be identified in both eyes for a trial to be marked for rejection, following Feldmann-Wustefeld & Awh, 2020. In the past, an artifact in either eye would produce rejection.